### PR TITLE
Fix mouse events for dynamic elements

### DIFF
--- a/public/js/jtrt-responsive-tables-public.js
+++ b/public/js/jtrt-responsive-tables-public.js
@@ -34,7 +34,7 @@
 		var jtrt_tables = $('.jtrt-table');
 		jtrt_tables.each(function(element) {
 			
-			var table = jQuery(jtrt_tables[element]);
+			var table = $(jtrt_tables[element]);
 			var id = table.attr('data-jtrt-table-id');
 			var jtrt_table_data = JSON.parse($('textarea#jtrt_table_settings_'+id).html());
 			
@@ -158,21 +158,21 @@
 			checkTableWidth($('.jtrespo-stack table'));
 		});
 
-		$('.highlightRows tr').on('mouseenter',function(){
+		$('.highlightRows').on('mouseenter', 'tbody tr', function(){
 			$(this).css('background',$('.highlightRows').attr('data-jtrt-rowhighligh-color'));
 		});
-		$('.highlightRows tr').on('mouseleave',function(){
+		$('.highlightRows').on('mouseleave', 'tbody tr', function(){
 			$(this).css('background','inherit');
 		});
 
 
-		$('.highlightCols td').on('mouseenter',function(){
+		$('.highlightCols').on('mouseenter', 'tbody td', function(){
 			var eq = $(this).index() + 1;
-			$('.highlightCols td:nth-child('+eq+')').css('background',$('.highlightCols').attr('data-jtrt-colhighligh-color'));
+			$('.highlightCols tbody td:nth-child('+eq+')').css('background',$('.highlightCols').attr('data-jtrt-colhighligh-color'));
 		});
-		$('.highlightCols td').on('mouseleave',function(){
+		$('.highlightCols').on('mouseleave', 'tbody td', function(){
 			var eq = $(this).index() + 1;
-			$('.highlightCols td:nth-child('+eq+')').css('background','inherit');
+			$('.highlightCols tbody td:nth-child('+eq+')').css('background','inherit');
 		});
 
 		


### PR DESCRIPTION
Fixes an issue where paginated `td` elements, beyond the first page, failed to trigger mouse events, because they are dynamically created.